### PR TITLE
BugFix: Fix the bug that using the branch name as the docker name

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,9 +23,12 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Set branch name to an output variable
+        id: set_branch
+        run: echo "BRANCH_NAME=${GITHUB_REF##*/}" >> $GITHUB_ENV
       -
         name: Build and push
         uses: docker/build-push-action@v5
         with:
           push: true
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/goplus-community-${{ github.ref_name }}:latest
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/goplus-community-${{ env.BRANCH_NAME }}:latest


### PR DESCRIPTION
# Problem
When there is a slash in the branch name, using the branch name as the name of the docker repository will cause the problem of identifying the owner of the docker repository incorrectly.

# Solution
Get the name to the right of the last slash line of the branch name by `##*/`.

# Test Results
![image](https://github.com/IRONICBo/community/assets/133086269/07b246a1-9c13-4fa7-9308-a73abb1c62b0)
